### PR TITLE
Revert "Déclaration d'une variable unique dans les boucles"

### DIFF
--- a/Client/GameEntities/Objects/GameMap.vb
+++ b/Client/GameEntities/Objects/GameMap.vb
@@ -37,15 +37,13 @@ Public Class GameMap
 
     ' TODO : Générer 2 RenderTexture à la création de la map
     Public Sub Draw(target As RenderTarget, states As RenderStates) Implements Drawable.Draw
-        Dim sprt As Sprite
-
         For x = 0 To 20
             For y = 0 To 14
                 For z = 0 To 3
                     If Not layer(z).tileCode(x, y) = 0 Then
                         ' TODO : Try Catch Le cas où le tileset voulu n'a pas été chargé
                         ' Console.WriteLine(.tileset(x, y).ToString())
-                        Using sprt = New Sprite(GameDesigner.TILESETS_MEMORY_DATA.ElementAt(layer(z).tileset(x, y)))
+                        Using sprt As New Sprite(GameDesigner.TILESETS_MEMORY_DATA.ElementAt(layer(z).tileset(x, y)))
                             sprt.TextureRect = New IntRect(GameTileset.DecodeX(layer(z).tileCode(x, y)) * 32, GameTileset.DecodeY(layer(z).tileCode(x, y)) * 32, 32, 32)
                             sprt.Position = New Vector2f(x * 32, y * 32)
                             target.Draw(sprt)
@@ -59,14 +57,13 @@ Public Class GameMap
     ' TODO : Remplacer par le deuxième RenderTexture
     Public Sub Draw2(target As RenderTarget, states As RenderStates)
         Dim sprt As Sprite
-
         For x = 0 To 20
             For y = 0 To 14
                 For z = 3 To 6
                     If Not layer(z).tileCode(x, y) = 0 Then
                         ' TODO : Try Catch Le cas où le tileset voulu n'a pas été chargé
                         ' Console.WriteLine(.tileset(x, y).ToString())
-                        Using sprt = New Sprite(GameDesigner.TILESETS_MEMORY_DATA.ElementAt(layer(z).tileset(x, y)))
+                        Using sprt As New Sprite(GameDesigner.TILESETS_MEMORY_DATA.ElementAt(layer(z).tileset(x, y)))
                             sprt.TextureRect = New IntRect(GameTileset.DecodeX(layer(z).tileCode(x, y)) * 32, GameTileset.DecodeY(layer(z).tileCode(x, y)) * 32, 32, 32)
                             sprt.Position = New Vector2f(x * 32, y * 32)
                             target.Draw(sprt)

--- a/Editeur/Database/BinaryDataBase.vb
+++ b/Editeur/Database/BinaryDataBase.vb
@@ -28,7 +28,6 @@ Public Class BinaryDataBase
 
     ' - Chargement des classes
     Private Sub LoadClasses()
-        Dim reader As Stream
         Dim deserializer As New BinaryFormatter
         Dim num As Integer
         Dim tmp As New GameClass
@@ -45,7 +44,6 @@ Public Class BinaryDataBase
 
     ' - Chargement des objets
     Private Sub LoadItems()
-        Dim reader As Stream
         Dim deserializer As New BinaryFormatter
         Dim num As Integer
         Dim tmp As New GameItem
@@ -62,7 +60,6 @@ Public Class BinaryDataBase
 
     ' - Chargement des sorts
     Private Sub LoadSpells()
-        Dim reader As Stream
         Dim deserializer As New BinaryFormatter
         Dim num As Integer
         Dim tmp As New GameSpell
@@ -79,7 +76,6 @@ Public Class BinaryDataBase
 
     ' - Chargement des PNJs
     Private Sub LoadNPCs()
-        Dim reader As Stream
         Dim deserializer As New BinaryFormatter
         Dim num As Integer
         Dim tmp As New GameNPC

--- a/Editeur/GameManager.vb
+++ b/Editeur/GameManager.vb
@@ -232,13 +232,11 @@ Class GameManager
             mapSurface(layer).Clear(New Color(0, 0, 0, 0))
         End If
 
-        Dim sprt As Sprite
-
         With map.MapLayer(layer)
             For x = 0 To modVar.MAP_WIDTH
                 For y = 0 To modVar.MAP_HEIGHT
                     If Not .tileCode(x, y) = 0 Then
-                        Using sprt = New Sprite(game.tileset(.tileset(x, y)))
+                        Using sprt As New Sprite(game.tileset(.tileset(x, y)))
                             sprt.TextureRect = New IntRect(GameTileset.DecodeX(.tileCode(x, y)) * modVar.CASE_LENGTH, GameTileset.DecodeY(.tileCode(x, y)) * modVar.CASE_LENGTH, modVar.CASE_LENGTH, modVar.CASE_LENGTH)
                             sprt.Position = New Vector2f(x * modVar.CASE_LENGTH, y * modVar.CASE_LENGTH)
                             mapSurface(layer).Draw(sprt)

--- a/Editeur/Maps/GameMap.vb
+++ b/Editeur/Maps/GameMap.vb
@@ -101,13 +101,11 @@ Public Class GameMap
         Dim layerSurface As New RenderTexture(672, 480)
         layerSurface.Clear(New Color(0, 0, 0, 0))
 
-        Dim sprt As Sprite
-
         With map.layer(layerNum)
             For x = 0 To 20
                 For y = 0 To 14
                     If Not layer(layerNum).tileCode(x, y) = 0 Then
-                        Using sprt = New Sprite(game.tileset(.tileset(x, y)))
+                        Using sprt As New Sprite(game.tileset(.tileset(x, y)))
                             sprt.TextureRect = New IntRect(GameTileset.DecodeX(.tileCode(x, y)) * 32, GameTileset.DecodeY(.tileCode(x, y)) * 32, 32, 32)
                             sprt.Position = New Vector2f(x * 32, y * 32)
                             layerSurface.Draw(sprt)


### PR DESCRIPTION
Il faut revert la Pull Request #5, ça ne compile plus si elle est appliquée.
Pas moyen de savoir pourquoi VS ne m'a pas hurlé dessus plus tôt... Toutes mes excuses.

Clément se basera sur la version précédente pour mieux gérer les scopes des Sprites.