### PR TITLE
Correction de l'issue #8 (NullReferenceException dans TGUI)

### DIFF
--- a/Client/Main.vb
+++ b/Client/Main.vb
@@ -83,6 +83,9 @@ Module Main
 
             ' ----- FIN DE TEST -----
 
+            ' FIX issue #8 : TGUI n'initialise pas son presse-papier. On s'en occupe pour lui...
+            TGUI.Global.Clipboard = String.Empty
+
             While (Window.IsOpen())
                 Window.DispatchEvents()
                 Designer.DispatchEventsAndUpdate()


### PR DESCRIPTION
TGUI n'initialise pas son presse-papier.
Si on colle (Ctrl+V) dans une EditBox avant de copier du texte, une
NullReferenceException est lancée.

Pour éviter ça, on fait le boulot de la lib à sa place.